### PR TITLE
Exclude node_modules from repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules


### PR DESCRIPTION
Prevent node_modules to be a part of a repo. Even though right  now its not in the repo, by not having it in `.gitignore` it makes it hard to use important feature of some editors to perform fuzzy search and so on.
