### PR TITLE
Replace on() with addEventListener()

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,7 +519,7 @@ const clipboard = remote.clipboard
 When the user clicks on the "Copy HTML" button, we'll go ahead and write the contents of the `$htmlView` element to the clipboard.
 
 ```js
-$copyHtmlButton.on('click', () => {
+$copyHtmlButton.addEventListener('click', () => {
   const html = $htmlView.innerHTML
   clipboard.writeText(html)
 })


### PR DESCRIPTION
# What does this PR do?
It replaces on() with addEventListener().

This was probably missed when jQuery was replaced with the native DOM
API https://github.com/feross/electron-workshop/pull/11

P.S.
Thanks for the workshop. It is really good! 🔥  🔑 